### PR TITLE
created admin part (no auth for the moment)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,16 @@ import YouTube from './pages/YouTube';
 import Legal from './pages/Legal';
 import Privacy from './pages/Privacy';
 import Creation from './pages/Creation';
+import Admin from './pages/Admin';
+import AdminEvents from './pages/admin/AdminEvents';
+import AdminGallery from './pages/admin/AdminGallery';
+import AdminBiography from './pages/admin/AdminBiography';
+import AdminInfo from './pages/admin/AdminInfo';
+import AdminMessages from './pages/admin/AdminMessages';
+import AdminSettings from './pages/admin/AdminSettings';
+import AdminGalleryTattoo from './pages/admin/gallery/AdminGalleryTattoo';
+import AdminGalleryFlash from './pages/admin/gallery/AdminGalleryFlash';
+import AdminGalleryWallpaper from './pages/admin/gallery/AdminGalleryWallpaper';
 import { ThemeProvider } from './hooks/useTheme';
 
 const STORAGE_KEY = 'lockscreen-completed';
@@ -51,6 +61,16 @@ function App() {
                 <Route path="legal" element={<Legal />} />
                 <Route path="privacy" element={<Privacy />} />
                 <Route path="creation" element={<Creation />} />
+                <Route path="admin" element={<Admin />} />
+                <Route path="admin/evenements" element={<AdminEvents />} />
+                <Route path="admin/galerie" element={<AdminGallery />} />
+                <Route path="admin/galerie/tattoo" element={<AdminGalleryTattoo />} />
+                <Route path="admin/galerie/flash" element={<AdminGalleryFlash />} />
+                <Route path="admin/galerie/wallpaper" element={<AdminGalleryWallpaper />} />
+                <Route path="admin/biographie" element={<AdminBiography />} />
+                <Route path="admin/informations" element={<AdminInfo />} />
+                <Route path="admin/messages" element={<AdminMessages />} />
+                <Route path="admin/parametres" element={<AdminSettings />} />
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Route>
             </Routes>

--- a/frontend/src/components/admin/AdminBreadcrumb.tsx
+++ b/frontend/src/components/admin/AdminBreadcrumb.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+
+interface BreadcrumbItem {
+  label: string;
+  path?: string;
+}
+
+interface AdminBreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export default function AdminBreadcrumb({ items }: AdminBreadcrumbProps) {
+  return (
+    <div className="flex align-items-center gap-2 mb-6 text-sm">
+      <Link to="/admin" className="admin-breadcrumb-link">
+        <i className="pi pi-arrow-left text-xs" />
+        Administration
+      </Link>
+      {items.map((item, index) => (
+        <span key={index} className="flex align-items-center gap-2">
+          <span>/</span>
+          {item.path ? (
+            <Link to={item.path} className="admin-breadcrumb-link">{item.label}</Link>
+          ) : (
+            <span className="font-semibold">{item.label}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/AdminCard.tsx
+++ b/frontend/src/components/admin/AdminCard.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+
+interface AdminCardProps {
+  icon: string;
+  title: string;
+  description: string;
+  path: string;
+  buttonLabel?: string;
+  badge?: string;
+}
+
+export default function AdminCard({ 
+  icon, 
+  title, 
+  description, 
+  path, 
+  buttonLabel = 'Accéder',
+  badge 
+}: AdminCardProps) {
+  return (
+    <div className="p-6 rounded-lg border border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow">
+      <div className="flex align-items-center justify-content-between mb-4">
+        <div className="flex align-items-center gap-3">
+          <i className={`pi ${icon} text-2xl`} />
+          <h2 className="text-xl font-semibold">{title}</h2>
+        </div>
+        {badge && (
+          <span className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm">
+            {badge}
+          </span>
+        )}
+      </div>
+      <p className="text-sm opacity-70 mb-4">{description}</p>
+      <Link to={path} className="admin-btn">
+        {buttonLabel}
+        <i className="pi pi-arrow-right text-xs" />
+      </Link>
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/AdminEmptyState.tsx
+++ b/frontend/src/components/admin/AdminEmptyState.tsx
@@ -1,0 +1,16 @@
+interface AdminEmptyStateProps {
+  icon: string;
+  message: string;
+  hint?: string;
+}
+
+export default function AdminEmptyState({ icon, message, hint }: AdminEmptyStateProps) {
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-8 text-center">
+      <i className={`pi ${icon} text-4xl opacity-30 mb-4`} style={{ display: 'block' }} />
+      <p className="opacity-50">{message}</p>
+      {hint && <p className="text-sm opacity-30 mt-2">{hint}</p>}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/AdminPageHeader.tsx
+++ b/frontend/src/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,33 @@
+interface AdminPageHeaderProps {
+  title: string;
+  actionLabel?: string;
+  actionIcon?: string;
+  onAction?: () => void;
+  rightContent?: React.ReactNode;
+}
+
+export default function AdminPageHeader({ 
+  title, 
+  actionLabel, 
+  actionIcon,
+  onAction,
+  rightContent 
+}: AdminPageHeaderProps) {
+  return (
+    <div className="flex align-items-center justify-content-between mb-6">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      {rightContent ? (
+        rightContent
+      ) : actionLabel && (
+        <button 
+          onClick={onAction}
+          className="flex align-items-center gap-2 px-4 py-2 bg-dark-bg dark:bg-dark-text text-dark-text dark:text-dark-bg rounded-lg hover:opacity-90 transition-opacity"
+        >
+          {actionIcon && <i className={`pi ${actionIcon}`} />}
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,0 +1,5 @@
+export { default as AdminBreadcrumb } from './AdminBreadcrumb';
+export { default as AdminCard } from './AdminCard';
+export { default as AdminPageHeader } from './AdminPageHeader';
+export { default as AdminEmptyState } from './AdminEmptyState';
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,3 +127,55 @@
   box-shadow: none;
   cursor: pointer;
 }
+
+/* Admin button style */
+.admin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none !important;
+  transition: opacity 0.2s ease;
+}
+
+.admin-btn:hover {
+  opacity: 0.85;
+}
+
+.admin-btn:visited {
+  text-decoration: none !important;
+}
+
+.light .admin-btn {
+  background-color: #171617;
+  color: #f5f1e8 !important;
+}
+
+.dark .admin-btn {
+  background-color: #f5f1e8;
+  color: #171617 !important;
+}
+
+/* Admin breadcrumb link style */
+.admin-breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  text-decoration: none !important;
+  transition: opacity 0.2s ease;
+}
+
+.admin-breadcrumb-link:hover {
+  opacity: 0.7;
+}
+
+.light .admin-breadcrumb-link {
+  color: #171617 !important;
+}
+
+.dark .admin-breadcrumb-link {
+  color: #f5f1e8 !important;
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,0 +1,54 @@
+import { AdminCard } from '../components/admin';
+
+export default function Admin() {
+  const adminSections = [
+    {
+      icon: 'pi-calendar',
+      title: 'Événements',
+      description: 'Gérer les événements, dates et lieux.',
+      path: '/admin/evenements'
+    },
+    {
+      icon: 'pi-images',
+      title: 'Galerie',
+      description: 'Ajouter, modifier ou supprimer des images.',
+      path: '/admin/galerie'
+    },
+    {
+      icon: 'pi-user',
+      title: 'Biographie',
+      description: 'Modifier le contenu de la biographie.',
+      path: '/admin/biographie'
+    },
+    {
+      icon: 'pi-info-circle',
+      title: 'Informations',
+      description: 'Modifier les informations générales.',
+      path: '/admin/informations'
+    },
+    {
+      icon: 'pi-envelope',
+      title: 'Messages',
+      description: 'Consulter les messages reçus.',
+      path: '/admin/messages'
+    },
+    {
+      icon: 'pi-cog',
+      title: 'Paramètres',
+      description: 'Configurer le site et les préférences.',
+      path: '/admin/parametres'
+    }
+  ];
+
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold mb-6">Administration</h1>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {adminSections.map((section) => (
+          <AdminCard key={section.path} {...section} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminBiography.tsx
+++ b/frontend/src/pages/admin/AdminBiography.tsx
@@ -1,0 +1,48 @@
+import { AdminBreadcrumb, AdminPageHeader } from '../../components/admin';
+
+export default function AdminBiography() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Biographie' }]} />
+
+      <AdminPageHeader 
+        title="Gestion de la Biographie"
+        actionLabel="Enregistrer"
+        actionIcon="pi-save"
+      />
+
+      {/* Éditeur de biographie (placeholder) */}
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+        <div className="mb-4">
+          <label className="block text-sm font-semibold mb-2">Titre</label>
+          <input 
+            type="text" 
+            className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+            placeholder="Titre de la biographie"
+          />
+        </div>
+        
+        <div className="mb-4">
+          <label className="block text-sm font-semibold mb-2">Contenu</label>
+          <textarea 
+            className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent min-h-64"
+            placeholder="Écrivez la biographie ici..."
+            rows={12}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold mb-2">Photo de profil</label>
+          <div className="flex align-items-center gap-4">
+            <div className="w-24 h-24 rounded-full bg-gray-200 dark:bg-gray-700 flex align-items-center justify-content-center">
+              <i className="pi pi-user text-2xl opacity-30" />
+            </div>
+            <button className="px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg hover:opacity-70 transition-opacity">
+              Changer la photo
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminEvents.tsx
+++ b/frontend/src/pages/admin/AdminEvents.tsx
@@ -1,0 +1,37 @@
+import { AdminBreadcrumb, AdminPageHeader } from '../../components/admin';
+
+export default function AdminEvents() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Événements' }]} />
+
+      <AdminPageHeader 
+        title="Gestion des Événements"
+        actionLabel="Ajouter un événement"
+        actionIcon="pi-plus"
+      />
+
+      {/* Liste des événements (placeholder) */}
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-gray-100 dark:bg-gray-800">
+            <tr>
+              <th className="text-left px-4 py-3 font-semibold">Titre</th>
+              <th className="text-left px-4 py-3 font-semibold">Date</th>
+              <th className="text-left px-4 py-3 font-semibold">Lieu</th>
+              <th className="text-left px-4 py-3 font-semibold">Statut</th>
+              <th className="text-right px-4 py-3 font-semibold">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-t border-gray-200 dark:border-gray-700">
+              <td className="px-4 py-4 text-center opacity-50" colSpan={5}>
+                Aucun événement pour le moment
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminGallery.tsx
+++ b/frontend/src/pages/admin/AdminGallery.tsx
@@ -1,0 +1,49 @@
+import { AdminBreadcrumb, AdminCard } from '../../components/admin';
+
+export default function AdminGallery() {
+  const galleryCategories = [
+    {
+      icon: 'pi-pencil',
+      title: 'Tattoo',
+      description: 'Tattoos réalisés par l\'artiste.',
+      path: '/admin/galerie/tattoo',
+      count: 0
+    },
+    {
+      icon: 'pi-bolt',
+      title: 'Flash',
+      description: 'Dessins de tattoo proposés, mais non tatoués.',
+      path: '/admin/galerie/flash',
+      count: 0
+    },
+    {
+      icon: 'pi-desktop',
+      title: 'Wallpaper',
+      description: 'Fonds d\'écran de la page d\'accueil.',
+      path: '/admin/galerie/wallpaper',
+      count: 0
+    }
+  ];
+
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Galerie' }]} />
+
+      <h1 className="text-3xl font-bold mb-6">Gestion de la Galerie</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {galleryCategories.map((category) => (
+          <AdminCard 
+            key={category.path}
+            icon={category.icon}
+            title={category.title}
+            description={category.description}
+            path={category.path}
+            buttonLabel="Gérer"
+            badge={`${category.count} image${category.count !== 1 ? 's' : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminInfo.tsx
+++ b/frontend/src/pages/admin/AdminInfo.tsx
@@ -1,0 +1,92 @@
+import { AdminBreadcrumb, AdminPageHeader } from '../../components/admin';
+
+export default function AdminInfo() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Informations' }]} />
+
+      <AdminPageHeader 
+        title="Gestion des Informations"
+        actionLabel="Enregistrer"
+        actionIcon="pi-save"
+      />
+
+      {/* Formulaire d'informations */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Informations de contact */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">Contact</h2>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">Email</label>
+            <input 
+              type="email" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="contact@standottori.com"
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">Téléphone</label>
+            <input 
+              type="tel" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="+33 1 23 45 67 89"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold mb-2">Adresse</label>
+            <textarea 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="Adresse du studio"
+              rows={3}
+            />
+          </div>
+        </div>
+
+        {/* Réseaux sociaux */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">Réseaux sociaux</h2>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">Instagram</label>
+            <input 
+              type="url" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="https://instagram.com/standottori"
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">YouTube</label>
+            <input 
+              type="url" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="https://youtube.com/@standottori"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold mb-2">TikTok</label>
+            <input 
+              type="url" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="https://tiktok.com/@standottori"
+            />
+          </div>
+        </div>
+
+        {/* Horaires */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 lg:col-span-2">
+          <h2 className="text-xl font-semibold mb-4">Horaires d'ouverture</h2>
+          <textarea 
+            className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+            placeholder="Lundi - Vendredi : 10h - 19h&#10;Samedi : Sur rendez-vous&#10;Dimanche : Fermé"
+            rows={4}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminMessages.tsx
+++ b/frontend/src/pages/admin/AdminMessages.tsx
@@ -1,0 +1,40 @@
+import { AdminBreadcrumb, AdminPageHeader } from '../../components/admin';
+
+export default function AdminMessages() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Messages' }]} />
+
+      <AdminPageHeader 
+        title="Messages reçus"
+        rightContent={
+          <span className="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-full text-sm">
+            0 non lu(s)
+          </span>
+        }
+      />
+
+      {/* Liste des messages (placeholder) */}
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-gray-100 dark:bg-gray-800">
+            <tr>
+              <th className="text-left px-4 py-3 font-semibold">Expéditeur</th>
+              <th className="text-left px-4 py-3 font-semibold">Sujet</th>
+              <th className="text-left px-4 py-3 font-semibold">Date</th>
+              <th className="text-left px-4 py-3 font-semibold">Statut</th>
+              <th className="text-right px-4 py-3 font-semibold">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-t border-gray-200 dark:border-gray-700">
+              <td className="px-4 py-4 text-center opacity-50" colSpan={5}>
+                Aucun message reçu
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminSettings.tsx
+++ b/frontend/src/pages/admin/AdminSettings.tsx
@@ -1,0 +1,98 @@
+import { AdminBreadcrumb } from '../../components/admin';
+
+export default function AdminSettings() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[{ label: 'Paramètres' }]} />
+
+      <h1 className="text-3xl font-bold mb-6">Paramètres</h1>
+
+      <div className="flex flex-column gap-6">
+        {/* Section: Apparence */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">Apparence</h2>
+          
+          <div className="flex align-items-center justify-content-between py-3 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <p className="font-medium">Thème par défaut</p>
+              <p className="text-sm opacity-50">Choisir le thème affiché aux visiteurs</p>
+            </div>
+            <select className="px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent">
+              <option value="light">Clair</option>
+              <option value="dark">Sombre</option>
+              <option value="system">Système</option>
+            </select>
+          </div>
+
+          <div className="flex align-items-center justify-content-between py-3">
+            <div>
+              <p className="font-medium">Écran de verrouillage</p>
+              <p className="text-sm opacity-50">Activer l'écran de verrouillage à l'entrée</p>
+            </div>
+            <label className="relative inline-flex align-items-center cursor-pointer">
+              <input type="checkbox" className="sr-only peer" defaultChecked />
+              <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-dark-bg dark:peer-checked:bg-dark-text"></div>
+            </label>
+          </div>
+        </div>
+
+        {/* Section: SEO */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">SEO & Métadonnées</h2>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">Titre du site</label>
+            <input 
+              type="text" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="Standottori - Tattoo Artist"
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-2">Description</label>
+            <textarea 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="Description du site pour les moteurs de recherche..."
+              rows={3}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-semibold mb-2">Mots-clés</label>
+            <input 
+              type="text" 
+              className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-transparent"
+              placeholder="tattoo, artiste, paris, standottori"
+            />
+          </div>
+        </div>
+
+        {/* Section: Compte */}
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+          <h2 className="text-xl font-semibold mb-4">Compte administrateur</h2>
+          
+          <div className="flex align-items-center justify-content-between py-3 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <p className="font-medium">Changer le mot de passe</p>
+              <p className="text-sm opacity-50">Modifier le mot de passe administrateur</p>
+            </div>
+            <button className="px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-lg hover:opacity-70 transition-opacity">
+              Modifier
+            </button>
+          </div>
+
+          <div className="flex align-items-center justify-content-between py-3">
+            <div>
+              <p className="font-medium text-red-500">Déconnexion</p>
+              <p className="text-sm opacity-50">Se déconnecter de l'administration</p>
+            </div>
+            <button className="px-4 py-2 bg-red-500 text-white rounded-lg hover:opacity-90 transition-opacity">
+              Déconnexion
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/gallery/AdminGalleryFlash.tsx
+++ b/frontend/src/pages/admin/gallery/AdminGalleryFlash.tsx
@@ -1,0 +1,24 @@
+import { AdminBreadcrumb, AdminPageHeader, AdminEmptyState } from '../../../components/admin';
+
+export default function AdminGalleryFlash() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[
+        { label: 'Galerie', path: '/admin/galerie' },
+        { label: 'Flash' }
+      ]} />
+
+      <AdminPageHeader 
+        title="Flash (dessins proposés)"
+        actionLabel="Ajouter des images"
+        actionIcon="pi-upload"
+      />
+
+      <AdminEmptyState 
+        icon="pi-bolt"
+        message="Aucun flash dans la galerie"
+        hint='Cliquez sur "Ajouter des images" pour commencer'
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/gallery/AdminGalleryTattoo.tsx
+++ b/frontend/src/pages/admin/gallery/AdminGalleryTattoo.tsx
@@ -1,0 +1,24 @@
+import { AdminBreadcrumb, AdminPageHeader, AdminEmptyState } from '../../../components/admin';
+
+export default function AdminGalleryTattoo() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[
+        { label: 'Galerie', path: '/admin/galerie' },
+        { label: 'Tattoo' }
+      ]} />
+
+      <AdminPageHeader 
+        title="Tattoos réalisés"
+        actionLabel="Ajouter des images"
+        actionIcon="pi-upload"
+      />
+
+      <AdminEmptyState 
+        icon="pi-pencil"
+        message="Aucun tattoo dans la galerie"
+        hint='Cliquez sur "Ajouter des images" pour commencer'
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/gallery/AdminGalleryWallpaper.tsx
+++ b/frontend/src/pages/admin/gallery/AdminGalleryWallpaper.tsx
@@ -1,0 +1,28 @@
+import { AdminBreadcrumb, AdminPageHeader, AdminEmptyState } from '../../../components/admin';
+
+export default function AdminGalleryWallpaper() {
+  return (
+    <div className="p-6">
+      <AdminBreadcrumb items={[
+        { label: 'Galerie', path: '/admin/galerie' },
+        { label: 'Wallpaper' }
+      ]} />
+
+      <AdminPageHeader 
+        title="Fonds d'écran (Homepage)"
+        actionLabel="Ajouter des images"
+        actionIcon="pi-upload"
+      />
+
+      <p className="text-sm opacity-70 mb-6">
+        Ces images sont utilisées dans le carrousel de la page d'accueil.
+      </p>
+
+      <AdminEmptyState 
+        icon="pi-desktop"
+        message="Aucun fond d'écran dans la galerie"
+        hint='Cliquez sur "Ajouter des images" pour commencer'
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a first pass of the admin UI and navigation.
> 
> - New admin dashboard at `admin` with sections linking to management pages
> - Adds routes for `admin/*` (events, gallery + subpages, biography, info, messages, settings) in `App.tsx`
> - Introduces reusable admin components: `AdminBreadcrumb`, `AdminCard`, `AdminPageHeader`, `AdminEmptyState`
> - Implements placeholder UIs: tables/forms/editors for each admin page (no data wiring)
> - Extends `index.css` with admin-specific styles (`.admin-btn`, `.admin-breadcrumb-link`) for light/dark themes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88e7bdd47a5b03a2a478b69dd8520533a672677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->