### PR TITLE
oui oui baguette

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import GalleryFlash from './pages/gallery/GalleryFlash';
 import ThemeProvider from './context/ThemeProvider';
 import AuthProvider from './context/AuthProvider';
 import RequireAdmin from './components/admin/RequireAdmin';
+import { UnlockContext, OVERLAY_FADE_MS } from './hooks/useUnlock';
 import { isSupabaseConfigured } from './lib/supabase';
 import { getSiteSettings } from './lib/content';
 
@@ -42,34 +43,54 @@ function AdminFallback() {
   );
 }
 
+/** Auto-dismiss the lockscreen if the visitor doesn't interact */
+const LOCKSCREEN_TIMEOUT_MS = 20000;
+
 function App() {
   const [unlocked, setUnlocked] = useState<boolean>(
     () => localStorage.getItem(STORAGE_KEY) === '1'
   );
+  // The overlay stays mounted during its fade-out, then unmounts entirely
+  const [overlayGone, setOverlayGone] = useState<boolean>(unlocked);
 
   // The artist can disable the lock screen from the admin settings
   useEffect(() => {
     if (unlocked || !isSupabaseConfigured) return;
     getSiteSettings()
       .then((settings) => {
-        if (!settings.lockscreen_enabled) setUnlocked(true);
+        if (!settings.lockscreen_enabled) dismissLockscreen(false);
       })
       .catch(() => {
         // Settings unavailable: keep the lock screen (default behaviour)
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unlocked]);
 
-  const handleUnlock = () => {
-    localStorage.setItem(STORAGE_KEY, '1');
+  const dismissLockscreen = (remember: boolean) => {
+    if (remember) localStorage.setItem(STORAGE_KEY, '1');
     setUnlocked(true);
+    window.setTimeout(() => setOverlayGone(true), OVERLAY_FADE_MS);
   };
+
+  // Timeout: visitors who don't play the pattern still reach the site.
+  // Not remembered, so they get another chance at the pattern next visit.
+  useEffect(() => {
+    if (unlocked) return;
+    const id = window.setTimeout(() => dismissLockscreen(false), LOCKSCREEN_TIMEOUT_MS);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unlocked]);
 
   return (
     <ThemeProvider>
       <AuthProvider>
-        {unlocked ? (
-          <div className="animate-fade-zoom-out">
-            <BrowserRouter>
+        <UnlockContext.Provider value={{ unlocked }}>
+        {/* The app always renders underneath: unlocking crossfades into it
+            with no route change. The homepage logo lights up in the exact
+            spot where the lockscreen reveal left it (see Home.tsx), so the
+            app itself must not move - no zoom entrance here. */}
+        <div>
+          <BrowserRouter>
               <Suspense fallback={<AdminFallback />}>
                 <Routes>
                   <Route path="/" element={<Layout />}>
@@ -103,11 +124,25 @@ function App() {
                   </Route>
                 </Routes>
               </Suspense>
-            </BrowserRouter>
+          </BrowserRouter>
+        </div>
+
+        {/* Lockscreen overlay: dissolves into the page underneath on unlock */}
+        {!overlayGone && (
+          <div
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 100,
+              opacity: unlocked ? 0 : 1,
+              transition: `opacity ${OVERLAY_FADE_MS}ms ease-out`,
+              pointerEvents: unlocked ? 'none' : 'auto',
+            }}
+          >
+            <LockScreen onComplete={() => dismissLockscreen(true)} />
           </div>
-        ) : (
-          <LockScreen onComplete={handleUnlock} />
         )}
+        </UnlockContext.Provider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/frontend/src/features/carousel/Carousel.css
+++ b/frontend/src/features/carousel/Carousel.css
@@ -1,0 +1,55 @@
+/* Carousel slide transitions.
+   The incoming slide covers the previous one: whole from the top, whole
+   from the bottom, or cut in two halves meeting in the middle.
+   Keep the 0.7s duration in sync with TRANSITION_MS (Carousel.tsx). */
+
+.carousel-slide--in-top {
+  animation: carouselInTop 0.7s cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
+.carousel-slide--in-bottom {
+  animation: carouselInBottom 0.7s cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
+/* Split: the same slide rendered twice, each copy clipped to one half.
+   clip-path applies before transform, so each half only needs to travel
+   its own height (50%) to land exactly in place - the two bands slide
+   in together and meet in the middle. */
+.carousel-slide--split-top {
+  clip-path: inset(0 0 50% 0);
+  animation: carouselInTopHalf 0.7s cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
+.carousel-slide--split-bottom {
+  clip-path: inset(50% 0 0 0);
+  animation: carouselInBottomHalf 0.7s cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
+.carousel-slide--fade {
+  animation: carouselFade 0.7s ease both;
+}
+
+@keyframes carouselInTop {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes carouselInBottom {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes carouselInTopHalf {
+  from { transform: translateY(-50%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes carouselInBottomHalf {
+  from { transform: translateY(50%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes carouselFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/frontend/src/features/carousel/Carousel.tsx
+++ b/frontend/src/features/carousel/Carousel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import './Carousel.css';
 
 interface CarouselImage {
   src: string;
@@ -11,11 +12,37 @@ interface CarouselProps {
   autoPlayInterval?: number;
   className?: string;
   isFullscreen?: boolean;
+  /** Optional custom first slide (e.g. the homepage brand stage) */
+  leadingSlide?: React.ReactNode;
+  /** Hold autoplay (e.g. while the entrance animation plays) */
+  paused?: boolean;
 }
 
-export default function Carousel({ images, autoPlayInterval = 5000, className = '', isFullscreen = false }: CarouselProps) {
+/** Keep in sync with the animation durations in Carousel.css */
+const TRANSITION_MS = 700;
+
+/** The incoming slide covers the previous one from a random direction */
+const VARIANTS = ['in-top', 'in-bottom', 'split'] as const;
+type Variant = (typeof VARIANTS)[number] | 'fade';
+
+function pickVariant(): Variant {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return 'fade';
+  return VARIANTS[Math.floor(Math.random() * VARIANTS.length)];
+}
+
+export default function Carousel({
+  images,
+  autoPlayInterval = 5000,
+  className = '',
+  isFullscreen = false,
+  leadingSlide,
+  paused = false,
+}: CarouselProps) {
   const { t } = useTranslation();
   const [currentIndex, setCurrentIndex] = useState(0);
+  // Previous slide stays visible underneath while the new one animates in
+  const [prevIndex, setPrevIndex] = useState<number | null>(null);
+  const [variant, setVariant] = useState<Variant>('fade');
   // Respect reduced-motion preferences: no autoplay
   const [isPlaying, setIsPlaying] = useState(
     () => !window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -23,20 +50,51 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
   const touchStartX = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const slideCount = images.length + (leadingSlide ? 1 : 0);
+
+  const goToSlide = useCallback(
+    (index: number) => {
+      setCurrentIndex((current) => {
+        if (index === current || slideCount < 2) return current;
+        setPrevIndex(current);
+        setVariant(pickVariant());
+        return index;
+      });
+    },
+    [slideCount]
+  );
+
   const nextSlide = useCallback(() => {
-    setCurrentIndex((current) => (current + 1) % images.length);
-  }, [images.length]);
+    setCurrentIndex((current) => {
+      if (slideCount < 2) return current;
+      setPrevIndex(current);
+      setVariant(pickVariant());
+      return (current + 1) % slideCount;
+    });
+  }, [slideCount]);
 
   const previousSlide = useCallback(() => {
-    setCurrentIndex((current) => (current - 1 + images.length) % images.length);
-  }, [images.length]);
+    setCurrentIndex((current) => {
+      if (slideCount < 2) return current;
+      setPrevIndex(current);
+      setVariant(pickVariant());
+      return (current - 1 + slideCount) % slideCount;
+    });
+  }, [slideCount]);
+
+  // Drop the previous slide once the incoming animation has landed
+  useEffect(() => {
+    if (prevIndex === null) return;
+    const id = window.setTimeout(() => setPrevIndex(null), TRANSITION_MS + 50);
+    return () => window.clearTimeout(id);
+  }, [prevIndex, currentIndex]);
 
   // Auto-play functionality
   useEffect(() => {
-    if (!isPlaying) return;
+    if (!isPlaying || paused) return;
     const timer = setInterval(nextSlide, autoPlayInterval);
     return () => clearInterval(timer);
-  }, [isPlaying, nextSlide, autoPlayInterval]);
+  }, [isPlaying, paused, nextSlide, autoPlayInterval]);
 
   // Pause on hover/focus
   const handleMouseEnter = () => setIsPlaying(false);
@@ -49,10 +107,10 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (touchStartX.current === null) return;
-    
+
     const touchEndX = e.changedTouches[0].clientX;
     const diff = touchStartX.current - touchEndX;
-    
+
     if (Math.abs(diff) > 50) { // minimum swipe distance
       if (diff > 0) {
         nextSlide();
@@ -81,9 +139,68 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
     }
   };
 
-  const fullscreenClasses = isFullscreen 
-    ? 'fixed inset-0 w-screen h-screen z-0' 
+  const fullscreenClasses = isFullscreen
+    ? 'fixed inset-0 w-screen h-screen z-0'
     : 'relative rounded-lg';
+
+  // Unified slide list: optional custom slide first, then the images.
+  // All slides stay mounted (images load once); only current/prev are visible.
+  const slides: React.ReactNode[] = [
+    ...(leadingSlide ? [leadingSlide] : []),
+    ...images.map((image, i) => (
+      <img
+        src={image.src}
+        alt={image.alt}
+        className="w-full h-full object-cover"
+        loading={i === 0 && !leadingSlide ? 'eager' : 'lazy'}
+      />
+    )),
+  ];
+
+  const renderSlide = (slide: React.ReactNode, index: number) => {
+    const isCurrent = index === currentIndex;
+    const isPrev = index === prevIndex;
+    const isEntering = isCurrent && prevIndex !== null;
+
+    if (!isCurrent && !isPrev) {
+      return (
+        <div key={index} className="absolute inset-0 invisible" aria-hidden="true">
+          {slide}
+        </div>
+      );
+    }
+
+    // Split: the incoming slide is cut in half - the top half drops in
+    // from above while the bottom half rises from below
+    if (isEntering && variant === 'split') {
+      return (
+        <div key={index} className="absolute inset-0 z-20" aria-hidden={false}>
+          <div className="absolute inset-0 carousel-slide--split-top">{slide}</div>
+          <div className="absolute inset-0 carousel-slide--split-bottom" aria-hidden="true">
+            {slide}
+          </div>
+        </div>
+      );
+    }
+
+    const enterClass = isEntering
+      ? variant === 'in-top'
+        ? 'carousel-slide--in-top'
+        : variant === 'in-bottom'
+          ? 'carousel-slide--in-bottom'
+          : 'carousel-slide--fade'
+      : '';
+
+    return (
+      <div
+        key={index}
+        className={`absolute inset-0 ${isCurrent ? 'z-20' : 'z-10'} ${enterClass}`}
+        aria-hidden={!isCurrent}
+      >
+        {slide}
+      </div>
+    );
+  };
 
   return (
     <div
@@ -98,34 +215,17 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
       role="region"
       aria-label={t('carousel.label')}
     >
-      {/* Images */}
-      <div 
-        className="flex transition-transform duration-500 ease-out h-full cursor-pointer"
-        style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        onClick={nextSlide}
-      >
-        {images.map((image, index) => (
-          <div
-            key={index}
-            className="min-w-full h-full"
-            aria-hidden={index !== currentIndex}
-          >
-            <img
-              src={image.src}
-              alt={image.alt}
-              className="w-full h-full object-cover"
-              loading={index === 0 ? 'eager' : 'lazy'}
-            />
-          </div>
-        ))}
+      {/* Slides */}
+      <div className="relative w-full h-full cursor-pointer" onClick={nextSlide}>
+        {slides.map(renderSlide)}
       </div>
 
       {/* Dots indicator */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
-        {images.map((_, index) => (
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2 z-30">
+        {slides.map((_, index) => (
           <button
             key={index}
-            onClick={() => setCurrentIndex(index)}
+            onClick={() => goToSlide(index)}
             className={`w-2 h-2 rounded-full transition-colors ${
               index === currentIndex
                 ? 'bg-white'
@@ -140,7 +240,7 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
       {/* Play/Pause button */}
       <button
         onClick={() => setIsPlaying(!isPlaying)}
-        className="absolute bottom-4 right-4 p-2 rounded-full bg-black/30 text-white hover:bg-black/50 focus:outline-none focus:ring-2 focus:ring-white/50"
+        className="absolute bottom-4 right-4 p-2 rounded-full bg-black/30 text-white hover:bg-black/50 focus:outline-none focus:ring-2 focus:ring-white/50 z-30"
         aria-label={isPlaying ? t('carousel.pause') : t('carousel.play')}
       >
         {isPlaying ? (
@@ -155,4 +255,4 @@ export default function Carousel({ images, autoPlayInterval = 5000, className = 
       </button>
     </div>
   );
-} 
+}

--- a/frontend/src/features/home/LogoSlide.tsx
+++ b/frontend/src/features/home/LogoSlide.tsx
@@ -1,0 +1,95 @@
+import { useTheme } from '../../hooks/useTheme';
+import { OVERLAY_FADE_MS } from '../../hooks/useUnlock';
+
+/** Full neon treatment (same recipe as the lockscreen reveal) */
+const NEON_DARK = [
+  'drop-shadow(0 0 4px #fff)',
+  'drop-shadow(0 0 10px #ff2ec8)',
+  'drop-shadow(0 0 24px #ff00aa)',
+  'drop-shadow(0 0 48px #c00080)',
+  'drop-shadow(0 0 80px rgba(179, 7, 179, 0.7))',
+].join(' ');
+
+/** Neon logo display width - MUST match the lockscreen reveal geometry */
+const LOGO_WIDTH = 'min(70vw, 420px)';
+/**
+ * logocreuse is square with more padding than logowsd.
+ * Scale so the ink bbox matches the neon logo's visual size.
+ * (logowsd fill≈0.943 width, logocreuse fill≈0.709 -> x1.331)
+ */
+const LIGHT_LOGO_WIDTH = 'min(93.2vw, 559px)';
+
+interface LogoSlideProps {
+  /** Logo visible (entrance done or in progress) */
+  revealed: boolean;
+  /** Fast light-up synced with the lockscreen overlay fade */
+  handoff: boolean;
+  /** Entrance finished: idle flicker only, instant theme swaps */
+  entranceComplete: boolean;
+}
+
+/**
+ * First slide of the homepage carousel: the brand stage.
+ * Dark -> neon logo over the glowing floor plate. Light -> engraved asset.
+ * The logo sits at the EXACT spot where the lockscreen reveal leaves it,
+ * so unlocking is a seamless crossfade with zero movement.
+ */
+export default function LogoSlide({ revealed, handoff, entranceComplete }: LogoSlideProps) {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const logoTransition = entranceComplete
+    ? undefined
+    : handoff
+      ? `opacity ${OVERLAY_FADE_MS}ms ease-out`
+      : 'opacity 2.6s ease-in-out 0.15s';
+
+  const stageClass = !revealed
+    ? ''
+    : entranceComplete
+      ? 'playground-stage-ready'
+      : 'playground-stage-awake';
+
+  if (!isDark) {
+    return (
+      <div className="relative w-full h-full overflow-hidden bg-[#f8f8f8]">
+        <div className="relative z-[1] w-full h-full flex flex-col items-center justify-center px-4">
+          <img
+            src="/images/logocreuse.png"
+            alt="Standottori logo"
+            className="h-auto select-none"
+            style={{
+              width: LIGHT_LOGO_WIDTH,
+              opacity: revealed ? 1 : 0,
+              transition: logoTransition,
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full h-full overflow-hidden bg-[#000000]">
+      <div
+        aria-hidden="true"
+        className={`playground-stage-bg absolute inset-0 ${stageClass}`}
+        style={revealed ? undefined : { opacity: 0 }}
+      />
+
+      <div className="relative z-[1] w-full h-full flex flex-col items-center justify-center px-4">
+        <img
+          src="/images/logowsd.png"
+          alt="Standottori logo"
+          className="h-auto select-none"
+          style={{
+            width: LOGO_WIDTH,
+            filter: NEON_DARK,
+            opacity: revealed ? 1 : 0,
+            transition: logoTransition,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/lockscreen/LockScreen.tsx
+++ b/frontend/src/features/lockscreen/LockScreen.tsx
@@ -1,16 +1,144 @@
+import { useRef, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
 import PatternGrid from './PatternGrid';
 
+/* Swap for /images/logosobre.png once the asset exists */
+const REVEAL_LOGO_DARK = '/images/logowsd.png';
+const REVEAL_LOGO_LIGHT = '/images/logocreuse.png';
+
+/** Full neon treatment for the reveal logo (same recipe as the playground) */
+const REVEAL_NEON = [
+  'drop-shadow(0 0 4px #fff)',
+  'drop-shadow(0 0 10px #ff2ec8)',
+  'drop-shadow(0 0 24px #ff00aa)',
+  'drop-shadow(0 0 48px #c00080)',
+  'drop-shadow(0 0 80px rgba(179, 7, 179, 0.7))',
+].join(' ');
+
+/*
+ * Timeline, from pattern validation (t=0):
+ *  - 0 .. 1.5s   energy flows through the figure (PatternGrid CSS, ENERGY_FILL_MS)
+ *  - 0.5s        onPatternSuccess fires -> "charged" (ambient glow arms itself)
+ *  - 1.5 .. 2.9s ambient pink glow floods the lockscreen
+ *  - 2.4s        reveal: the figure flares and overloads into a blinding flash;
+ *                under the peak, the logo appears at its FINAL resting spot
+ *                (same geometry as the playground logo - no movement after)
+ *  - 5.0s        onComplete -> the app unlocks underneath (0.9s crossfade,
+ *                the playground logo lights up in the same spot)
+ */
+const GLOW_DELAY_MS = 1000;
+const GLOW_SPREAD_MS = 1400;
+const BLOOM_HOLD_MS = 1900;
+/* Flash peaks at ~0.6s, dies at ~2.2s (revealFlash in PatternGrid.css);
+   leave a short beat with the logo standing alone before unlocking */
+const REVEAL_COMPLETE_MS = 2600;
+
+type Phase = 'pattern' | 'charged' | 'reveal';
+
 export default function LockScreen({ onComplete }: { onComplete: () => void }) {
   const { theme } = useTheme();
-  const backgroundColor = theme === 'light' ? '#F4EDDE' : '#171617';
+  const isDark = theme === 'dark';
+  const [phase, setPhase] = useState<Phase>('pattern');
+  const unlockStarted = useRef(false);
+
+  const handlePatternSuccess = () => {
+    if (unlockStarted.current) return; // already unlocking
+    unlockStarted.current = true;
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced) {
+      onComplete();
+      return;
+    }
+
+    setPhase('charged');
+    window.setTimeout(() => {
+      setPhase('reveal');
+      window.setTimeout(onComplete, REVEAL_COMPLETE_MS);
+    }, BLOOM_HOLD_MS);
+  };
+
+  const isCharged = phase !== 'pattern';
+  const isRevealing = phase === 'reveal';
 
   return (
-    <div 
-      className="fixed inset-0" 
-      style={{ backgroundColor }}
+    <div
+      className="fixed inset-0 overflow-hidden"
+      style={{
+        background: isDark
+          ? 'radial-gradient(ellipse 120% 80% at 50% 110%, rgba(179, 7, 179, 0.18) 0%, rgba(0, 0, 0, 0) 55%), #000000'
+          : 'radial-gradient(ellipse 120% 90% at 50% 40%, #ffffff 0%, #f4f2ee 100%)',
+      }}
     >
-      <PatternGrid onPatternSuccess={onComplete} />
+      {/* Ambient glow: once the figure is full of light, the energy overflows
+          and floods the whole lockscreen */}
+      {isDark && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background:
+              'radial-gradient(ellipse 95% 80% at 50% 50%, rgba(255, 46, 200, 0.35) 0%, rgba(179, 7, 179, 0.18) 45%, rgba(0, 0, 0, 0) 80%)',
+            opacity: isCharged ? 1 : 0,
+            transition: `opacity ${GLOW_SPREAD_MS}ms ease-in ${GLOW_DELAY_MS}ms`,
+          }}
+        />
+      )}
+
+      {/* Pattern stage: on reveal the figure flares (see .pattern-stage--reveal
+          in PatternGrid.css) and vanishes under the flash peak */}
+      <div
+        className={isRevealing ? 'pattern-stage--reveal' : undefined}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          opacity: isRevealing ? 0 : 1,
+          /* the figure vanishes under the flash peak (~0.6s..1.0s) */
+          transition: 'opacity 0.5s ease-in 0.5s',
+          pointerEvents: isRevealing ? 'none' : 'auto',
+        }}
+      >
+        <PatternGrid onPatternSuccess={handlePatternSuccess} />
+      </div>
+
+      {/* Reveal stage: the logo appears directly at its FINAL resting spot -
+          identical geometry to the playground logo, so after the flash there
+          is no movement at all, just the crossfade to the app */}
+      <div
+        aria-hidden={!isRevealing}
+        className="absolute inset-0 flex items-center justify-center pointer-events-none"
+      >
+        <img
+          src={isDark ? REVEAL_LOGO_DARK : REVEAL_LOGO_LIGHT}
+          alt="Standottori"
+          className="select-none h-auto"
+          style={{
+            width: isDark ? 'min(70vw, 420px)' : 'min(93.2vw, 559px)',
+            filter: isDark ? REVEAL_NEON : 'none',
+            opacity: isRevealing ? 1 : 0,
+            /* pre-rasterise this heavy layer (large PNG + filters) so the
+               reveal doesn't jank at the exact moment of the flash */
+            willChange: 'opacity',
+            /* materialises under the flash peak, unveiled as it decays */
+            transition: 'opacity 0.9s ease-in 0.4s',
+          }}
+        />
+      </div>
+
+      {/* Reveal flash: the energy overloads into a blinding bloom whose peak
+          masks the pattern->logo swap - the eye cannot track shapes through
+          peak brightness, so the figure appears to transmute into the logo.
+          Kept mounted (opacity 0) so its first paint doesn't delay the attack. */}
+      <div
+        aria-hidden="true"
+        className={`absolute inset-0 pointer-events-none ${isRevealing ? 'reveal-flash' : ''}`}
+        style={{
+          opacity: 0,
+          background: isDark
+            ? 'radial-gradient(circle at 50% 52%, #ffffff 0%, #ffd9f3 18%, rgba(255, 46, 200, 0.9) 42%, rgba(179, 7, 179, 0.5) 68%, transparent 88%)'
+            : 'radial-gradient(circle at 50% 52%, #ffffff 0%, #ffffff 30%, rgba(255, 255, 255, 0.7) 60%, transparent 88%)',
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/features/lockscreen/PatternGrid.css
+++ b/frontend/src/features/lockscreen/PatternGrid.css
@@ -1,4 +1,6 @@
-/* PatternGrid.css - Styling for the graphical unlock screen pattern grid */
+/* PatternGrid.css - Styling for the graphical unlock screen pattern grid
+   Dark mode: the pattern is drawn as neon light (brand magenta).
+   Light mode: the pattern is drawn as ink on a mineral surface. */
 
 .full-screen {
   width: 100vw;
@@ -6,64 +8,127 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  /* Fallback if PrimeFlex doesn't load */
+  /* Leave headroom for the brand mark above the pattern */
+  padding-top: 10vh;
+  box-sizing: border-box;
 }
 
 .pattern-container {
   position: relative;
-  /* Responsive sizing based on viewport */
-  width: clamp(250px, 70vw, 500px);
-  height: clamp(250px, 70vh, 500px);
-  /* Keep the smaller dimension to maintain square */
   width: min(clamp(250px, 70vw, 500px), clamp(250px, 70vh, 500px));
   height: min(clamp(250px, 70vw, 500px), clamp(250px, 70vh, 500px));
-  /* Ensure no overflow on any screen size */
   max-width: 90vw;
   max-height: 90vh;
-  border: 2px solid transparent; /* keeps success/error border colours from shifting the layout */
 }
+
+/* ---------- Points ----------
+   A generous invisible hit area around a tiny solid dot.
+   The order number sits OUTSIDE the dot, on the outward side of the figure,
+   and fades away once the node is connected. */
 
 .pattern-point {
   position: absolute;
-  /* Responsive point size */
-  width: clamp(16px, 4vw, 24px);
-  height: clamp(16px, 4vw, 24px);
-  background-color: #ff0000;
-  border-radius: 50%;
+  width: clamp(36px, 9vw, 48px);
+  height: clamp(36px, 9vw, 48px);
   transform: translate(-50%, -50%);
-  /* Smooth transitions for future interactions */
-  transition: all 0.2s ease;
-  /* Make sure points are visible */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
   z-index: 10;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
-/* Mobile-specific adjustments */
-@media (max-width: 768px) {
-  .pattern-container {
-    width: clamp(200px, 80vw, 350px);
-    height: clamp(200px, 80vw, 350px);
-  }
-  
-  .pattern-point {
-    width: clamp(14px, 5vw, 20px);
-    height: clamp(14px, 5vw, 20px);
-  }
+/* The dot itself: tiny, solid, always visible */
+.pattern-point::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-/* Large screen adjustments */
-@media (min-width: 1200px) {
-  .pattern-container {
-    width: clamp(400px, 50vw, 600px);
-    height: clamp(400px, 50vw, 600px);
-  }
-  
-  .pattern-point {
-    width: clamp(20px, 3vw, 28px);
-    height: clamp(20px, 3vw, 28px);
-  }
+/* Discreet order number, floated outside the dot */
+.pattern-point__num {
+  position: absolute;
+  font-size: 10px;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: 0.05em;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
 }
 
-/* SVG overlay for drawing lines */
+/* Each number sits on the outward side of the figure so it never
+   collides with the drawn lines (point layout: a top, b/c right,
+   d bottom, e/f left) */
+.pattern-point--a .pattern-point__num {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -2px);
+}
+
+.pattern-point--b .pattern-point__num,
+.pattern-point--c .pattern-point__num {
+  left: 100%;
+  top: 50%;
+  transform: translate(2px, -50%);
+}
+
+.pattern-point--d .pattern-point__num {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 2px);
+}
+
+.pattern-point--e .pattern-point__num,
+.pattern-point--f .pattern-point__num {
+  right: 100%;
+  top: 50%;
+  transform: translate(-2px, -50%);
+}
+
+.dark .pattern-point::after { background-color: rgba(255, 255, 255, 0.4); }
+.dark .pattern-point__num { color: rgba(255, 255, 255, 0.35); }
+
+.light .pattern-point::after { background-color: rgba(23, 22, 23, 0.4); }
+.light .pattern-point__num { color: rgba(23, 22, 23, 0.4); }
+
+.dark .pattern-point:hover::after { background-color: rgba(255, 255, 255, 0.75); }
+.light .pattern-point:hover::after { background-color: rgba(23, 22, 23, 0.75); }
+
+/* Reached: the dot brightens, the number retires.
+   While drawing the light stays white - the neon is earned by finishing. */
+.pattern-point.selected .pattern-point__num { opacity: 0; }
+
+.dark .pattern-point.selected::after {
+  background-color: #ffffff;
+  transform: scale(1.3);
+}
+
+.light .pattern-point.selected::after {
+  background-color: #171617;
+  transform: scale(1.3);
+}
+
+/* First node again: quiet pulse inviting to close the loop */
+.pattern-point.can-close::after {
+  animation: dotPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes dotPulse {
+  0%, 100% { transform: scale(1.3); }
+  50% { transform: scale(1.9); }
+}
+
+/* ---------- Lines ---------- */
+
 .drawing-overlay {
   position: absolute;
   top: 0;
@@ -72,37 +137,297 @@
   height: 100%;
   pointer-events: none;
   z-index: 5;
+  overflow: visible;
 }
 
+/* Crisp hairline core over a wide soft halo - segments are pre-trimmed in
+   the TSX so they stop at the node rings instead of stabbing through them */
 .drawn-line {
-  stroke: #000;
-  stroke-width: 0.8;
   fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  stroke-linecap: butt;
+  stroke-width: 0.4;
+  transition: stroke 0.3s ease;
 }
+
+.drawn-line-halo {
+  fill: none;
+  stroke-linecap: butt;
+  stroke-width: 1.4;
+}
+
+.dark .drawn-line { stroke: rgba(255, 255, 255, 0.92); }
+.dark .drawn-line-halo { stroke: rgba(255, 255, 255, 0.09); }
+
+.light .drawn-line { stroke: rgba(23, 22, 23, 0.9); }
+.light .drawn-line-halo { stroke: rgba(23, 22, 23, 0.07); }
 
 .preview-line {
-  stroke: rgba(0, 0, 0, 0.4);
-  stroke-width: 0.6;
+  fill: none;
+  stroke-linecap: butt;
+  stroke-width: 0.35;
+  stroke-dasharray: 1.4 2.1;
+}
+
+.dark .preview-line {
+  stroke: rgba(255, 255, 255, 0.3);
+}
+
+.light .preview-line {
+  stroke: rgba(23, 22, 23, 0.35);
+}
+
+/* ---------- Idle hint ----------
+   After a few seconds of inactivity a finger demonstrates the gesture:
+   it slides along the first segment of the pattern (node 1 -> node 2),
+   then fades and repeats. Pure CSS loop; removed as soon as the user
+   touches a node. */
+
+.pattern-hint {
+  position: absolute;
+  left: 50%;
+  top: 5%;
+  width: 0;
+  height: 0;
+  z-index: 15;
+  pointer-events: none;
+  opacity: 0;
+  animation: hintSlide 3.2s ease-in-out infinite;
+  animation-delay: 0.2s;
+}
+
+/* Touch halo under the fingertip */
+.pattern-hint__touch {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.dark .pattern-hint__touch {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.light .pattern-hint__touch {
+  background: rgba(23, 22, 23, 0.06);
+  border: 1px solid rgba(23, 22, 23, 0.3);
+}
+
+/* Pointing hand, fingertip anchored on the centre of the touch halo */
+.pattern-hint__hand {
+  position: absolute;
+  left: -14px;
+  top: -5px;
+  width: 30px;
+  height: 30px;
+}
+
+.dark .pattern-hint__hand path { fill: rgba(255, 255, 255, 0.85); }
+.light .pattern-hint__hand path { fill: rgba(23, 22, 23, 0.8); }
+
+/* Node 1 sits at (50%, 5%), node 2 at (85%, 70%): fade in on the first
+   node, glide to the second, fade out, pause, repeat */
+@keyframes hintSlide {
+  0% { left: 50%; top: 5%; opacity: 0; }
+  12% { left: 50%; top: 5%; opacity: 1; }
+  62% { left: 85%; top: 70%; opacity: 1; }
+  76% { left: 85%; top: 70%; opacity: 0; }
+  100% { left: 85%; top: 70%; opacity: 0; }
+}
+
+/* ---------- Validation states ---------- */
+
+/* Success: neon energy flows through the figure like liquid light in a tube.
+   Both paths share pathLength=100, so dash values are percentages of the
+   travel. Keep the 1.5s duration in sync with ENERGY_FILL_MS (PatternGrid.tsx). */
+
+/* The illuminated trail left behind the moving head */
+.energy-trail {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-dasharray: 2 2;
+  stroke-width: 1;
+  stroke-dasharray: 100 100;
+  stroke-dashoffset: 100;
 }
 
-/* Container validation states */
-.pattern-container.success {
-  border-color: #00ff00;
-  box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
+.dark .energy-trail {
+  stroke: #ffffff;
+  filter:
+    drop-shadow(0 0 2px #ffffff)
+    drop-shadow(0 0 7px #ff2ec8)
+    drop-shadow(0 0 18px #ff00aa)
+    drop-shadow(0 0 40px rgba(192, 0, 128, 0.8));
+  animation: energyFill 1.5s ease-in-out forwards;
 }
 
-.pattern-container.error {
-  border-color: #ff0000;
-  box-shadow: 0 0 20px rgba(255, 0, 0, 0.3);
+/* Bright leading edge: a short dash whose front edge matches the trail's
+   reveal front for every progress value (offset = 6 - 100p vs 100 - 100p) */
+.energy-head {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.4;
+  stroke-dasharray: 6 200;
+  stroke-dashoffset: 6;
 }
 
-/* Shake animation for errors */
+.dark .energy-head {
+  stroke: #ffffff;
+  filter:
+    drop-shadow(0 0 3px #ffffff)
+    drop-shadow(0 0 10px #ffffff)
+    drop-shadow(0 0 22px #ff2ec8);
+  animation: energyHeadTravel 1.5s ease-in-out forwards;
+}
+
+@keyframes energyFill {
+  from { stroke-dashoffset: 100; }
+  to { stroke-dashoffset: 0; }
+}
+
+@keyframes energyHeadTravel {
+  0% { stroke-dashoffset: 6; opacity: 1; }
+  88% { opacity: 1; }
+  100% { stroke-dashoffset: -94; opacity: 0; }
+}
+
+/* Light mode has no neon: the trail simply confirms in ink */
+.light .energy-trail {
+  stroke: #000000;
+  animation: energyFill 1.5s ease-in-out forwards;
+}
+
+.light .energy-head {
+  display: none;
+}
+
+/* ---------- Reveal flare ----------
+   The lit figure does not shrink away: its strokes thicken and blaze
+   while the logo brightens in the exact same box, so the pattern
+   appears to morph into the logo. */
+
+.dark .pattern-stage--reveal .energy-trail {
+  stroke-dashoffset: 0;
+  /* builds directly into the flash peak (~0.6s) */
+  animation: trailFlare 0.7s ease-in forwards;
+}
+
+@keyframes trailFlare {
+  0% {
+    stroke-width: 1;
+    filter:
+      drop-shadow(0 0 2px #ffffff)
+      drop-shadow(0 0 7px #ff2ec8)
+      drop-shadow(0 0 18px #ff00aa)
+      drop-shadow(0 0 40px rgba(192, 0, 128, 0.8));
+  }
+  100% {
+    stroke-width: 3.2;
+    filter:
+      drop-shadow(0 0 4px #ffffff)
+      drop-shadow(0 0 14px #ff2ec8)
+      drop-shadow(0 0 34px #ff00aa)
+      drop-shadow(0 0 70px #c00080)
+      drop-shadow(0 0 120px rgba(179, 7, 179, 0.9));
+  }
+}
+
+.dark .pattern-stage--reveal .energy-head {
+  display: none;
+}
+
+.dark .pattern-stage--reveal .pattern-point.selected::after {
+  background-color: #ff2ec8;
+  animation: pointFlare 0.7s ease-in forwards;
+}
+
+@keyframes pointFlare {
+  to {
+    transform: scale(1.9);
+    box-shadow:
+      0 0 14px rgba(255, 255, 255, 0.95),
+      0 0 34px rgba(255, 46, 200, 1),
+      0 0 70px rgba(255, 0, 170, 0.8);
+  }
+}
+
+/* Flash that masks the pattern->logo swap: fast attack to peak brightness,
+   short hold while the swap happens underneath, slow decay unveiling the logo */
+.reveal-flash {
+  opacity: 0;
+  animation: revealFlash 2.2s ease-in-out forwards;
+}
+
+@keyframes revealFlash {
+  0% { opacity: 0; }
+  28% { opacity: 1; }
+  46% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Node dots ignite when the energy head passes through (delay set inline) */
+.dark .pattern-container.success .pattern-point.selected::after {
+  animation: pointIgnite 0.4s ease-out forwards;
+  animation-delay: var(--ignite-delay, 0ms);
+}
+
+@keyframes pointIgnite {
+  0% {
+    background-color: #ffffff;
+    box-shadow: none;
+  }
+  40% {
+    background-color: #ffffff;
+    box-shadow:
+      0 0 12px rgba(255, 255, 255, 0.95),
+      0 0 30px rgba(255, 46, 200, 0.9);
+  }
+  100% {
+    background-color: #ff2ec8;
+    box-shadow:
+      0 0 8px rgba(255, 255, 255, 0.8),
+      0 0 20px rgba(255, 46, 200, 0.95),
+      0 0 44px rgba(255, 0, 170, 0.65);
+  }
+}
+
+.light .pattern-container.success .drawn-line {
+  stroke: #000000;
+}
+
+.pattern-container.error .drawn-line {
+  transition: none;
+}
+
+.dark .pattern-container.error .drawn-line {
+  stroke: #ff5c5c;
+}
+
+.dark .pattern-container.error .drawn-line-halo {
+  stroke: rgba(255, 60, 60, 0.12);
+}
+
+.light .pattern-container.error .drawn-line {
+  stroke: #b3261e;
+}
+
+.light .pattern-container.error .drawn-line-halo {
+  stroke: rgba(179, 38, 30, 0.1);
+}
+
+.dark .pattern-container.error .pattern-point.selected::after {
+  background-color: #ff5c5c;
+  box-shadow: 0 0 10px rgba(255, 60, 60, 0.6);
+}
+
+.light .pattern-container.error .pattern-point.selected::after {
+  background-color: #b3261e;
+}
+
 .pattern-container.shake {
   animation: shake 0.6s ease-in-out;
 }
@@ -113,74 +438,70 @@
   20%, 40%, 60%, 80% { transform: translateX(5px); }
 }
 
-/* Point states */
-.pattern-point {
-  cursor: pointer;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-}
+/* ---------- Buttons & messages ---------- */
 
-.pattern-point.selected {
-  background-color: #00ff00;
-  box-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
-}
-
-.pattern-point.can-close {
-  background-color: #ffaa00;
-  box-shadow: 0 0 10px rgba(255, 170, 0, 0.7);
-  animation: pulse 1s infinite;
-}
-
-@keyframes pulse {
-  0% { transform: translate(-50%, -50%) scale(1); }
-  50% { transform: translate(-50%, -50%) scale(1.2); }
-  100% { transform: translate(-50%, -50%) scale(1); }
-}
-
-/* Reset button */
 .reset-button {
   position: absolute;
-  bottom: -50px;
+  bottom: -48px;
   left: 50%;
   transform: translateX(-50%);
-  padding: 8px 16px;
-  background-color: #ff4444;
-  color: white;
-  border: none;
-  border-radius: 4px;
+  padding: 8px 22px;
+  background: transparent;
+  border: 1px solid;
+  border-radius: 999px;
   cursor: pointer;
-  font-size: 14px;
-  transition: all 0.2s ease;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
   z-index: 20;
 }
 
-.reset-button:hover:not(:disabled) {
-  background-color: #ff6666;
-  transform: translateX(-50%) scale(1.05);
+.dark .reset-button {
+  color: rgba(255, 255, 255, 0.75);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.light .reset-button {
+  color: rgba(23, 22, 23, 0.8);
+  border-color: rgba(23, 22, 23, 0.3);
+}
+
+.dark .reset-button:hover:not(:disabled) {
+  color: #ffffff;
+  border-color: #ff2ec8;
+}
+
+.light .reset-button:hover:not(:disabled) {
+  color: #171617;
+  border-color: #171617;
 }
 
 .reset-button:disabled {
-  background-color: #cccccc;
+  opacity: 0.25;
   cursor: not-allowed;
 }
 
-/* Error message */
 .error-message {
   position: absolute;
-  bottom: -60px;
+  bottom: -80px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 14px;
-  color: #ff0000;
-  background: rgba(255, 255, 255, 0.9);
-  padding: 6px 12px;
-  border-radius: 6px;
-  border: 1px solid #ff0000;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  background: transparent;
+  padding: 4px 8px;
   white-space: nowrap;
   z-index: 25;
   animation: fadeIn 0.3s ease-in-out;
+}
+
+.dark .error-message {
+  color: #ff8080;
+}
+
+.light .error-message {
+  color: #b3261e;
 }
 
 @keyframes fadeIn {
@@ -188,50 +509,88 @@
   to { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 
-/* Discreet accessible skip link (keyboard / assistive tech alternative) */
+/* Discreet accessible skip link (keyboard / assistive tech alternative).
+   Bottom-right corner: keeps the centre free for the error message. */
 .skip-button {
   position: fixed;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 12px;
+  right: 16px;
   padding: 6px 12px;
   background: transparent;
   border: none;
-  color: #888;
   font-size: 12px;
   text-decoration: underline;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0.5;
   transition: opacity 0.2s ease;
   z-index: 30;
 }
+
+.dark .skip-button { color: rgba(255, 255, 255, 0.6); }
+.light .skip-button { color: rgba(23, 22, 23, 0.6); }
 
 .skip-button:hover,
 .skip-button:focus-visible {
   opacity: 1;
 }
 
-/* Individual point positioning - now handled by inline styles in React */
-.pattern-point--a {
-  /* Position handled by React inline styles */
+/* ---------- Responsive sizing ---------- */
+
+@media (max-width: 768px) {
+  .pattern-container {
+    width: clamp(200px, 80vw, 350px);
+    height: clamp(200px, 80vw, 350px);
+  }
+
+  .pattern-point::after {
+    width: 6px;
+    height: 6px;
+  }
+
+  .pattern-point__num {
+    font-size: 9px;
+  }
 }
 
-.pattern-point--b {
-  /* Position handled by React inline styles */
+@media (min-width: 1200px) {
+  .pattern-container {
+    width: clamp(400px, 50vw, 600px);
+    height: clamp(400px, 50vw, 600px);
+  }
+
+  .pattern-point::after {
+    width: 8px;
+    height: 8px;
+  }
 }
 
-.pattern-point--c {
-  /* Position handled by React inline styles */
-}
+@media (prefers-reduced-motion: reduce) {
+  .pattern-point.can-close::after,
+  .pattern-container.shake,
+  .pattern-hint,
+  .energy-trail,
+  .energy-head,
+  .dark .pattern-container.success .pattern-point.selected::after {
+    animation: none;
+  }
 
-.pattern-point--d {
-  /* Position handled by React inline styles */
-}
+  /* Show the final lit state directly */
+  .energy-trail {
+    stroke-dashoffset: 0;
+  }
 
-.pattern-point--e {
-  /* Position handled by React inline styles */
-}
+  .energy-head {
+    display: none;
+  }
 
-.pattern-point--f {
-  /* Position handled by React inline styles */
+  /* Static hint at the starting node instead of the sliding gesture */
+  .pattern-hint {
+    left: 50%;
+    top: 5%;
+    opacity: 0.8;
+  }
+
+  .dark .pattern-container.success .pattern-point.selected::after {
+    background-color: #ff2ec8;
+  }
 }

--- a/frontend/src/features/lockscreen/PatternGrid.tsx
+++ b/frontend/src/features/lockscreen/PatternGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import './PatternGrid.css';
 
@@ -25,6 +25,22 @@ const POINTS: Point[] = [
 // Correct pattern sequence
 const CORRECT_PATTERN = ['a', 'c', 'f', 'd', 'b', 'e', 'a'];
 
+// Duration of the neon energy flowing through the completed pattern.
+// Keep in sync with the energyFill/energyHead animations in PatternGrid.css.
+const ENERGY_FILL_MS = 1500;
+
+// Discreet guide numbers: order in which the nodes must be connected
+const NODE_ORDER: Record<string, number> = {};
+CORRECT_PATTERN.forEach((id) => {
+  if (!(id in NODE_ORDER)) NODE_ORDER[id] = Object.keys(NODE_ORDER).length + 1;
+});
+
+// Lines stop just short of the dots (in viewBox units, i.e. % of container)
+const NODE_GAP = 2;
+
+// Idle time before the "slide to connect" finger hint appears
+const HINT_DELAY_MS = 5000;
+
 // Helper function to compare two arrays
 function arraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((val, index) => val === b[index]);
@@ -38,7 +54,19 @@ const PatternGrid: React.FC<PatternGridProps> = ({ onPatternSuccess }) => {
   const [validationState, setValidationState] = useState<'idle' | 'success' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [isShaking, setIsShaking] = useState(false);
+  const [showHint, setShowHint] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Finger hint after a few idle seconds; hides on interaction, re-arms
+  // whenever the pattern is empty again (e.g. after a reset)
+  useEffect(() => {
+    if (isDrawing || selectedPoints.length > 0 || validationState !== 'idle') {
+      setShowHint(false);
+      return;
+    }
+    const id = window.setTimeout(() => setShowHint(true), HINT_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, [isDrawing, selectedPoints.length, validationState]);
 
   const resetPattern = () => {
     setSelectedPoints([]);
@@ -217,36 +245,90 @@ const PatternGrid: React.FC<PatternGridProps> = ({ onPatternSuccess }) => {
     return POINTS.find(point => point.id === id);
   };
 
-  // Generate SVG path for drawn lines
+  // Drawn lines as separate hairline segments, each trimmed so it starts and
+  // ends at the edge of the node rings (never crossing them)
   const generatePath = (): string => {
     if (selectedPoints.length < 2) return '';
-    
-    const pathCommands: string[] = [];
-    
+
+    const parts: string[] = [];
     for (let i = 0; i < selectedPoints.length - 1; i++) {
-      const currentPoint = getPointById(selectedPoints[i]);
-      const nextPoint = getPointById(selectedPoints[i + 1]);
-      
-      if (currentPoint && nextPoint) {
-        if (i === 0) {
-          pathCommands.push(`M ${currentPoint.x} ${currentPoint.y}`);
-        }
-        pathCommands.push(`L ${nextPoint.x} ${nextPoint.y}`);
-      }
+      const p1 = getPointById(selectedPoints[i]);
+      const p2 = getPointById(selectedPoints[i + 1]);
+      if (!p1 || !p2) continue;
+
+      const dx = p2.x - p1.x;
+      const dy = p2.y - p1.y;
+      const len = Math.hypot(dx, dy);
+      if (len <= NODE_GAP * 2) continue;
+
+      const ux = dx / len;
+      const uy = dy / len;
+      parts.push(
+        `M ${(p1.x + ux * NODE_GAP).toFixed(2)} ${(p1.y + uy * NODE_GAP).toFixed(2)} ` +
+          `L ${(p2.x - ux * NODE_GAP).toFixed(2)} ${(p2.y - uy * NODE_GAP).toFixed(2)}`
+      );
     }
-    
-    return pathCommands.join(' ');
+    return parts.join(' ');
   };
 
   // Generate preview line from last selected point to current pointer
   const generatePreviewPath = (): string => {
     if (!isDrawing || selectedPoints.length === 0 || !currentPointer) return '';
-    
+
     const lastPoint = getPointById(selectedPoints[selectedPoints.length - 1]);
     if (!lastPoint) return '';
-    
-    return `M ${lastPoint.x} ${lastPoint.y} L ${currentPointer.x} ${currentPointer.y}`;
+
+    const dx = currentPointer.x - lastPoint.x;
+    const dy = currentPointer.y - lastPoint.y;
+    const len = Math.hypot(dx, dy);
+    if (len <= NODE_GAP) return '';
+
+    const ux = dx / len;
+    const uy = dy / len;
+    return (
+      `M ${(lastPoint.x + ux * NODE_GAP).toFixed(2)} ${(lastPoint.y + uy * NODE_GAP).toFixed(2)} ` +
+      `L ${currentPointer.x.toFixed(2)} ${currentPointer.y.toFixed(2)}`
+    );
   };
+
+  // Energy path: same figure but traced from the LAST touched node backwards,
+  // so the neon flows from where the finger lifted through the whole pattern
+  const generateEnergyPath = (): string => {
+    if (selectedPoints.length < 2) return '';
+
+    return [...selectedPoints]
+      .reverse()
+      .map((id, index) => {
+        const point = getPointById(id);
+        if (!point) return '';
+        return `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`;
+      })
+      .join(' ');
+  };
+
+  // For each node: at which fraction of the energy travel the head reaches it,
+  // so the dots ignite exactly when the light passes through them
+  const getIgnitionDelays = (): Record<string, number> => {
+    const reversed = [...selectedPoints].reverse();
+    const cumulative: number[] = [0];
+    let total = 0;
+
+    for (let i = 1; i < reversed.length; i++) {
+      const a = getPointById(reversed[i - 1]);
+      const b = getPointById(reversed[i]);
+      if (a && b) total += Math.hypot(b.x - a.x, b.y - a.y);
+      cumulative.push(total);
+    }
+
+    const delays: Record<string, number> = {};
+    reversed.forEach((id, i) => {
+      if (!(id in delays)) delays[id] = total > 0 ? cumulative[i] / total : 0;
+    });
+    return delays;
+  };
+
+  const isSuccess = validationState === 'success';
+  const ignitionDelays = isSuccess ? getIgnitionDelays() : null;
 
   return (
     <div className="full-screen">
@@ -266,27 +348,21 @@ const PatternGrid: React.FC<PatternGridProps> = ({ onPatternSuccess }) => {
           viewBox="0 0 100 100"
           preserveAspectRatio="none"
         >
-          {/* Main drawn path */}
-          <path
-            d={generatePath()}
-            className="drawn-line"
-            fill="none"
-            stroke="black"
-            strokeWidth="0.8"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
+          {/* Drawn path: a wide soft halo under a crisp hairline core
+              (stroke colours/effects come from the theme CSS) */}
+          <path d={generatePath()} className="drawn-line-halo" />
+          <path d={generatePath()} className="drawn-line" />
           {/* Preview line during dragging */}
-          <path
-            d={generatePreviewPath()}
-            className="preview-line"
-            fill="none"
-            stroke="rgba(0, 0, 0, 0.4)"
-            strokeWidth="0.6"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeDasharray="2 2"
-          />
+          <path d={generatePreviewPath()} className="preview-line" />
+          {/* Success: neon energy flows through the figure from the last
+              touched node. pathLength=100 normalises the geometry so the
+              CSS dash animations work in percentages. */}
+          {isSuccess && (
+            <>
+              <path d={generateEnergyPath()} className="energy-trail" pathLength={100} />
+              <path d={generateEnergyPath()} className="energy-head" pathLength={100} />
+            </>
+          )}
         </svg>
 
         {/* Interactive Points */}
@@ -307,10 +383,29 @@ const PatternGrid: React.FC<PatternGridProps> = ({ onPatternSuccess }) => {
                 top: `${point.y}%`,
                 left: `${point.x}%`,
                 cursor: 'pointer',
-              }}
-            />
+                // Each node ignites the moment the energy head reaches it
+                ...(ignitionDelays && point.id in ignitionDelays
+                  ? { '--ignite-delay': `${Math.round(ignitionDelays[point.id] * ENERGY_FILL_MS)}ms` }
+                  : {}),
+              } as React.CSSProperties}
+            >
+              {/* Discreet order guide - fades out once the node is reached */}
+              <span className="pattern-point__num" aria-hidden="true">
+                {NODE_ORDER[point.id]}
+              </span>
+            </div>
           );
         })}
+
+        {/* Idle hint: a finger sliding from node 1 to node 2 */}
+        {showHint && (
+          <div className="pattern-hint" aria-hidden="true">
+            <span className="pattern-hint__touch" />
+            <svg className="pattern-hint__hand" viewBox="0 0 24 24">
+              <path d="M9 11.24V7.5C9 6.12 10.12 5 11.5 5S14 6.12 14 7.5v3.74c1.21-.81 2-2.18 2-3.74C16 5.01 13.99 3 11.5 3S7 5.01 7 7.5c0 1.56.79 2.93 2 3.74zm9.84 4.63l-4.54-2.26c-.17-.07-.35-.11-.54-.11H13v-6c0-.83-.67-1.5-1.5-1.5S10 6.67 10 7.5v10.74l-3.43-.72c-.08-.01-.15-.03-.24-.03-.31 0-.59.13-.79.33l-.79.8 4.94 4.94c.27.27.65.44 1.06.44h6.79c.75 0 1.33-.55 1.44-1.28l.75-5.27c.01-.07.02-.14.02-.2 0-.62-.38-1.16-.91-1.38z" />
+            </svg>
+          </div>
+        )}
 
         {/* Reset Button */}
         <button

--- a/frontend/src/hooks/useUnlock.ts
+++ b/frontend/src/hooks/useUnlock.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+/** Lockscreen overlay fade-out duration (owned by App.tsx) */
+export const OVERLAY_FADE_MS = 900;
+
+export interface UnlockContextType {
+  /** True once the lockscreen has been dismissed (pattern, skip or timeout) */
+  unlocked: boolean;
+}
+
+/* Defaults to unlocked so components render normally outside the provider */
+export const UnlockContext = createContext<UnlockContextType>({ unlocked: true });
+
+export function useUnlock() {
+  return useContext(UnlockContext);
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Carousel from '../features/carousel/Carousel';
+import LogoSlide from '../features/home/LogoSlide';
+import { useUnlock } from '../hooks/useUnlock';
 import { isSupabaseConfigured, publicImageUrl } from '../lib/supabase';
 import { listGalleryImages } from '../lib/content';
 
@@ -14,8 +16,47 @@ const FALLBACK_IMAGES = [
   { src: '/images/tattoingStan.png', alt: 'Stan tattooing' },
 ];
 
+/** Covers logo fade + stage fade before autoplay may leave slide 1 */
+const ENTRANCE_TOTAL_MS = 3200;
+
 export default function Home() {
   const [images, setImages] = useState(FALLBACK_IMAGES);
+  const { unlocked } = useUnlock();
+
+  // Brand stage (slide 1) entrance:
+  //  - visitor unlocks live -> fast light-up synced with the overlay fade
+  //  - returning visitor (already unlocked) -> gentle one-time entrance
+  const [revealed, setRevealed] = useState(false);
+  const [handoff, setHandoff] = useState(false);
+  const [entranceComplete, setEntranceComplete] = useState(false);
+  const wasLockedAtMount = useRef(!unlocked);
+
+  useEffect(() => {
+    if (!unlocked || revealed) return;
+
+    if (wasLockedAtMount.current) {
+      // The lockscreen reveal left its logo at our exact spot: light ours
+      // up immediately so the crossfade never dips to black
+      setHandoff(true);
+      setRevealed(true);
+      return;
+    }
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced) {
+      setRevealed(true);
+      setEntranceComplete(true);
+      return;
+    }
+    const startId = window.setTimeout(() => setRevealed(true), 400);
+    return () => window.clearTimeout(startId);
+  }, [unlocked, revealed]);
+
+  useEffect(() => {
+    if (!revealed || entranceComplete) return;
+    const doneId = window.setTimeout(() => setEntranceComplete(true), ENTRANCE_TOTAL_MS);
+    return () => window.clearTimeout(doneId);
+  }, [revealed, entranceComplete]);
 
   useEffect(() => {
     if (!isSupabaseConfigured) return;
@@ -35,5 +76,14 @@ export default function Home() {
       });
   }, []);
 
-  return <Carousel images={images} isFullscreen={true} />;
+  return (
+    <Carousel
+      images={images}
+      isFullscreen={true}
+      leadingSlide={
+        <LogoSlide revealed={revealed} handoff={handoff} entranceComplete={entranceComplete} />
+      }
+      paused={!entranceComplete}
+    />
+  );
 }

--- a/frontend/src/pages/Playground.tsx
+++ b/frontend/src/pages/Playground.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTheme } from '../hooks/useTheme';
+import LockScreen from '../features/lockscreen/LockScreen';
+
+/* TEMP: lockscreen test rig - overlay fade must match App.tsx */
+const OVERLAY_FADE_MS = 900;
 
 const NEON_DARK = [
   'drop-shadow(0 0 4px #fff)',
@@ -29,7 +33,23 @@ export default function Playground() {
   const [revealed, setRevealed] = useState(false);
   const [entranceComplete, setEntranceComplete] = useState(false);
 
+  // TEMP: lockscreen test rig. The lockscreen always shows here (storage is
+  // never touched) and the playground entrance waits for it to dissolve.
+  const [locked, setLocked] = useState(true);
+  const [overlayGone, setOverlayGone] = useState(false);
+  const [handoff, setHandoff] = useState(false);
+
+  const dismissLock = () => {
+    setLocked(false);
+    // The lockscreen morph already settled its logo onto our logo's exact
+    // geometry: light ours up immediately so the crossfade never dips to black
+    setHandoff(true);
+    setRevealed(true);
+    window.setTimeout(() => setOverlayGone(true), OVERLAY_FADE_MS);
+  };
+
   useEffect(() => {
+    if (locked || revealed) return;
     const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (prefersReduced) {
       setRevealed(true);
@@ -38,7 +58,7 @@ export default function Playground() {
     }
     const startId = window.setTimeout(() => setRevealed(true), 400);
     return () => window.clearTimeout(startId);
-  }, []);
+  }, [locked, revealed]);
 
   useEffect(() => {
     if (!revealed || entranceComplete) return;
@@ -49,13 +69,31 @@ export default function Playground() {
 
   const logoTransition = entranceComplete
     ? undefined
-    : 'opacity 2.6s ease-in-out 0.15s';
+    : handoff
+      ? `opacity ${OVERLAY_FADE_MS}ms ease-out`
+      : 'opacity 2.6s ease-in-out 0.15s';
 
   const stageClass = !revealed
     ? ''
     : entranceComplete
       ? 'playground-stage-ready'
       : 'playground-stage-awake';
+
+  // TEMP: lockscreen overlay, same crossfade as the real one in App.tsx
+  const lockOverlay = !overlayGone && (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 100,
+        opacity: locked ? 1 : 0,
+        transition: `opacity ${OVERLAY_FADE_MS}ms ease-out`,
+        pointerEvents: locked ? 'auto' : 'none',
+      }}
+    >
+      <LockScreen onComplete={dismissLock} />
+    </div>
+  );
 
   if (!isDark) {
     return (
@@ -72,6 +110,7 @@ export default function Playground() {
             }}
           />
         </div>
+        {lockOverlay}
       </div>
     );
   }
@@ -97,6 +136,7 @@ export default function Playground() {
           }}
         />
       </div>
+      {lockOverlay}
     </div>
   );
 }


### PR DESCRIPTION
Both parts are done and verified on the real homepage. Here's the summary:

Unlock animation on the homepage. The neon stage from the Playground is now the first slide of the homepage carousel (new LogoSlide component). App.tsx shares the lockscreen state through a small unlock context, and Home.tsx uses it to choreograph the entrance:

Visitor draws the pattern → energy flow, glow, flash → the lockscreen logo appears at its resting spot → the overlay crossfades while the homepage logo lights up in the exact same place. No dip to black, no movement. The old zoom-in entrance on the app wrapper was removed since it would have shifted the logo during the handoff.
Returning visitors (no lockscreen) get the gentle 2.6s logo fade-in with the stage glow, once per visit.
The carousel autoplay is held until the logo entrance finishes, so it can't slide away mid-reveal.
New carousel transitions. The carousel no longer slides right-to-left. The incoming picture now covers the current one from a random direction each time:

From the top — the new slide drops down over the old one.
From the bottom — it rises up.
Split — the new picture is cut in half; the top half drops from above and the bottom half rises from below, meeting in the middle.
Reduced-motion users get a simple crossfade instead. All slides stay mounted so images load once, and dots / play-pause / swipe / keyboard navigation still work — including jumping back to the logo slide via the first dot.

I tested the whole flow headlessly: pattern → flash → handoff onto the homepage, then several transitions in both themes. One bug was caught and fixed during verification: the split halves originally traveled 100% of the screen height and shot past their clip window (making the transition invisible) — they now travel exactly their own half-height and land seamlessly. Here's the split mid-flight in light mode: